### PR TITLE
Use npx

### DIFF
--- a/FU.SPA/package.json
+++ b/FU.SPA/package.json
@@ -4,12 +4,12 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview",
-    "format": "prettier . --write",
-    "format-check": "prettier . --check"
+    "dev": "npx vite",
+    "build": "npx vite build",
+    "lint": "npx eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
+    "preview": "npx vite preview",
+    "format": "npx prettier . --write",
+    "format-check": "npx prettier . --check"
   },
   "dependencies": {
     "@emotion/react": "^11.11.1",


### PR DESCRIPTION
Use npx so that the dev dependencies are actually being used. This way you don't need to install the tools globally.
