### PR TITLE
updated workflow

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -5,7 +5,7 @@ name: Build ForcesUnite
 on: 
   workflow_dispatch:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [ready_for_review]
 
 jobs:
   build-api:


### PR DESCRIPTION
Recently changed it to run our build workflow manually. But when running it manually, it does not mark the status check on the opened mr as completed or not. So I changed it to also run the workflow when we open a new mr, or mark it as ready for review. Workflows kicked off due to these actions will mark the status check as completed