### PR TITLE
Update README info

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ Config settings are loaded from the environment variables. To automatically load
 
 Then set the `VITE_API_URL` environment variable
 ```
-VITE_API_URL=https://localhost:7171/api
+VITE_API_URL=https://localhost:PORT/api
 ```
+where `PORT` is the port number the API is running on. If there are CORS errors, change the URL to match `http://` instead of `https://` and this may resolve the issue.
 
 ## Running
 ### Running Web API


### PR DESCRIPTION
- Updates our documentation in README.md to reference .NET 7 specifically
- Fixes issue that would occur if running just `dotnet tool install --global dotnet-ef` because v8 is not compatible with v7 projects
- Add information regarding environment setup, retains to API port number and Cross Origin Resource Sharing issues