### PR TITLE
Change logo to use navigate

### DIFF
--- a/FU.SPA/src/components/Navbar.jsx
+++ b/FU.SPA/src/components/Navbar.jsx
@@ -91,7 +91,7 @@ export default function Navbar() {
             color: 'inherit',
             textDecoration: 'none',
             fontSize: '1.7rem',
-            cursor: 'pointer'
+            cursor: 'pointer',
           }}
         >
           Forces Unite


### PR DESCRIPTION
- Small fix to make main logo use `navigate` rather than an `href`/`anchor` link, helps to avoid reloading the DOM