### PR TITLE
fix create bug

### DIFF
--- a/FU.SPA/src/components/CreatePost.jsx
+++ b/FU.SPA/src/components/CreatePost.jsx
@@ -24,8 +24,8 @@ import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 export default function CreatePost() {
   const [game, setGame] = useState(null);
   const [title, setTitle] = useState('');
-  const [startTime, setStartTime] = useState(dayjs());
-  const [endTime, setEndTime] = useState(dayjs().add(30, 'minute'));
+  const [startTime, setStartTime] = useState(dayjs().add(30, 'minute'));
+  const [endTime, setEndTime] = useState(dayjs().add(35, 'minute'));
   const [description, setDescription] = useState('');
   const [tags, setTags] = useState([]);
   const navigate = useNavigate();


### PR DESCRIPTION
- When creating a post, if you dont change the start time then you get a create post error. This is because the start time is initially whatever time it is, but when the api is hit that start time is in the past. This sets the inital time to 30 minutes in the future